### PR TITLE
Eliminate ambiguous grammar for ':handles'

### DIFF
--- a/rfc/attributes.md
+++ b/rfc/attributes.md
@@ -39,7 +39,7 @@ HANDLES         ::= 'handles' '('
                                  |  '*'                              # this slot handles all unknown methods, but inheritance takes precedence
                               ')'
 DELEGATION      ::= IDENTIFIER | PAIR                                # A method or a map (to:from) this slot handles
-PAIR            ::= IDENTIFIER:IDENTIFIER                           
+PAIR            ::= IDENTIFIER ':' IDENTIFIER                           
 MODIFIER        ::= '(' IDENTIFIER ')'
 IDENTIFIER      ::= [:alpha:] {[:alnum:]}
 ```


### PR DESCRIPTION
As discussed on IRC: The grammar for method delegation needs to be able to distinguish between two identifiers (foo,bar) and one mapping (foo=>bar).  The syntax I propose has been presented on IRC and didn't get sufficient criticism.