### PR TITLE
add deps to makefile

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,6 +24,8 @@ my %WriteMakefileArgs = (
         'Syntax::Keyword::Try'   => '0.25',
         'Template::Tiny::Strict' => '1.18',
         'Regexp::Common'         => '2017060201',
+        'Readonly'               => '2.05',
+        'Type::Tiny'             => '1.012004',
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES    => 'Corinna-RFC-Writer-*' },


### PR DESCRIPTION
after installing a fresh perl v5.34.0 on osx 10.15.7 and cloning Cor, when
running:

prove -r -l -v t

I got:

t/corinna/rfc/config/reader.t ... Can't locate Readonly.pm in @INC

and then:

t/corinna/rfc/config/reader.t ... Can't locate Type/Library.pm in @INC

this commit adds those libraries to the Cor makefile