### PR TITLE
Fix typo in attributes.md

### DIFF
--- a/rfc/attributes.md
+++ b/rfc/attributes.md
@@ -122,7 +122,7 @@ class Soldier {
 
 # usage
 my $thing = Soldier->new(
-    is   => $required,
+    id   => $required,
     name => $optional_name, # this k/v pair can be omitted entirely
     rank => $optional_rank,
     sn   => $some_value,


### PR DESCRIPTION
Trivial edit to fix typo in attributes.md.