### PR TITLE
Trivial typo fix to mvp.md

### DIFF
--- a/templates/rfc/mvp.md
+++ b/templates/rfc/mvp.md
@@ -89,7 +89,7 @@ The metaobject protocol, similar to `Class::MOP`.
 
 ## 7. Method modifiers (around, before, after)
 
-The behave similarly to the `around`, `before`, and `after` method modifiers
+They behave similarly to the `around`, `before`, and `after` method modifiers
 from Moo/se.
 
 # Missing Features


### PR DESCRIPTION
Changed "The" to "They", as intended, I think.