### PR TITLE
Correct method override syntax in examples

### DIFF
--- a/templates/rfc/questions.md
+++ b/templates/rfc/questions.md
@@ -46,7 +46,7 @@ Cons:
 A method can override a parent method explicitly to avoid a warning:
 
 ```perl
-override method move($x,$y) {...}
+method move($x,$y) :overrides {...}
 ```
 
 Should methods generated via `field` attributes be allowed to override parents?


### PR DESCRIPTION
Method override with new syntax