### PR TITLE
Correct :overrides attribute spelling

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -67,7 +67,7 @@ We're doing this:
 
 ```perl
 class Foo :isa(Bar) :does(SomeRole) :version(v1.2.3) {
-    method some_method :override () {
+    method some_method :overrides () {
         ...
     }
 }


### PR DESCRIPTION
override -> override*s*