### PR TITLE
Fix "need to inherit" example

### DIFF
--- a/templates/rfc/faq.md
+++ b/templates/rfc/faq.md
@@ -38,7 +38,7 @@ No, you can't. Sorry. You can try `Object::Pad`, not use `class`, or
 investigate composition over inheritance:
 
 ```perl
-class My::Class;
+class My::Class {
     use Some::Bless::Class;
 
     field $arg_for_blessed :param(arg);


### PR DESCRIPTION
... which mixed `class My::Class;` declaration, which doesn't require a block scope, with indentation which suggests a block scope was wanted, and a close curly for block scope. Make it into a block scope, like other examples.